### PR TITLE
Enable (hybrid) relative line numbering in vim

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -110,7 +110,9 @@ set colorcolumn=+1
 
 " Numbers
 set number
+set relativenumber
 set numberwidth=5
+
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Colors and Fonts


### PR DESCRIPTION
This mode displays relative line numbers except for the cursor line.
