### PR TITLE
Add a shortcut for netrw's :Explore command

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -101,6 +101,9 @@ set tm=500
 " Add a bit extra margin to the left
 set foldcolumn=1
 
+" Short key for netrw
+nmap <silent> <Leader>e :Explore<CR>
+
 " Use NerdTree layout in explorer mode
 let g:netrw_liststyle=3
 


### PR DESCRIPTION
In a Rails project `:E` becomes ambiguous, so I addded `,e`
