### PR TITLE
Added shell alias to enable Chef environment

### DIFF
--- a/aliases
+++ b/aliases
@@ -16,7 +16,7 @@ alias s="rspec"
 alias path='echo $PATH | tr -s ":" "\n"'
 
 # Chef
-alias chefsh='eval $(chef shell-init ${SHELL##*/})'
+alias chefsh='eval "$(chef shell-init ${SHELL##*/})"'
 
 # Include custom aliases
 [[ -f ~/.aliases.local ]] && source ~/.aliases.local

--- a/aliases
+++ b/aliases
@@ -15,6 +15,9 @@ alias s="rspec"
 # Pretty print the path
 alias path='echo $PATH | tr -s ":" "\n"'
 
+# Chef
+alias chefsh='eval $(chef shell-init ${SHELL##*/})'
+
 # Include custom aliases
 [[ -f ~/.aliases.local ]] && source ~/.aliases.local
 


### PR DESCRIPTION
The `chefsh` makes it easier to switch to a Chef environment.
Easier than pronouncing the alias at least.
@freistil/ops
