### PR TITLE
map backslash to grep search

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -301,6 +301,9 @@ if executable('ag')
   let g:ctrlp_use_caching = 0
 endif
 
+" bind \ (backward slash) to grep shortcut
+command -nargs=+ -complete=file -bar Ag silent! grep! <args>|cwindow|redraw!
+nnoremap \ :Ag<SPACE>
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Spell checking


### PR DESCRIPTION
I need this a lot to search files. 

E.g. find all sites of a cluster `:Ag 'cluster.*c61' data_bags/websites`

What do you think, @freistil/ops 
