### PR TITLE
Optimised config for vim and tmux

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -1,3 +1,4 @@
+" Set font in graphical vim
 set guifont=Source\ Code\ Pro:h16
 
 " Launch Marked with file
@@ -6,10 +7,13 @@ set guifont=Source\ Code\ Pro:h16
 " Launch Dash with current keyword
 :nmap <silent> <leader>d <Plug>DashSearch
 
+" Disable balloon tooltips in Ruby files
+autocmd FileType ruby,eruby set noballooneval
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Include local configuration
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-if filereadable($HOME . "/.mvimrc.local")
-  source ~/.mvimrc.local
+if filereadable($HOME . "/.gvimrc.local")
+  source ~/.gvimrc.local
 endif
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,97 +1,115 @@
 #
-# terminal
+# Prefix keystroke
 #
 
-set -g default-terminal "screen-256color"
+# Set prefix to <Ctrl-s>
+# (easy to type and doesn't interfere with shell keystrokes like Ctrl-a)
+unbind C-b
+set-option -g prefix C-s
+# send prefix keystroke by pressing more than once
+bind -r C-s send-prefix
+
+# Reload configuration with <PREFIX> <r>
+bind-key r source-file ~/.tmux.conf \; display-message "~/.tmux.conf reloaded"
 
 #
-# window notifications
+# Windows
 #
 
 setw -g monitor-activity on
 set -g visual-activity on
 
+# Create new window with <PREFIX> <c> (open in working directory)
+bind c new-window -c '#{pane_current_path}'
+
 #
-# keys
+# Panes
 #
 
-# prefix key: Ctrl-a (like screen, easier to type)
-set-option -g prefix C-a
-bind a send-prefix
-
-# last-window like in screen
-bind C-a last-window
-
-# cycle through windows
-bind -r C-h select-window -t :-
-bind -r C-l select-window -t :+
-
-# split panes: | vertical, - horizontal
+# Split panes: <PREFIX> <|> vertical, <PREFIX> <-> horizontal
 unbind %
-bind | split-window -h
-bind - split-window -v
+bind | split-window -h -c '#{pane_current_path}'
+bind - split-window -v -c '#{pane_current_path}'
 
-# select panes
-bind h select-pane -L
-bind j select-pane -D
-bind k select-pane -U
-bind l select-pane -R
+# Select panes with <Ctrl-HJKL>, except when in vi
+is_vim='echo "#{pane_current_command}" | grep -iqE "(^|\/)g?(view|n?vim?)(diff)?$"'
+bind -n C-h if-shell "$is_vim" "send-keys C-h" "select-pane -L"
+bind -n C-j if-shell "$is_vim" "send-keys C-j" "select-pane -D"
+bind -n C-k if-shell "$is_vim" "send-keys C-k" "select-pane -U"
+bind -n C-l if-shell "$is_vim" "send-keys C-l" "select-pane -R"
+bind -n C-\ if-shell "$is_vim" "send-keys C-\\" "select-pane -l"
 
-# resize panes
-bind -r H resize-pane -L 5
-bind -r J resize-pane -D 5
-bind -r K resize-pane -U 5
-bind -r L resize-pane -R 5
+# Resize panes with <Shift>-<Cursor> or <Ctrl>-<Cursor>
+bind -n S-Left resize-pane -L 2
+bind -n S-Right resize-pane -R 2
+bind -n S-Down resize-pane -D 1
+bind -n S-Up resize-pane -U 1
+bind -n C-Left resize-pane -L 10
+bind -n C-Right resize-pane -R 10
+bind -n C-Down resize-pane -D 5
+bind -n C-Up resize-pane -U 5
 
-# Log output to a text file on demand
-bind P pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
+# Make current pane a new window with <PREFIX> <b>
+bind-key b break-pane -d
+
+bind-key C-j choose-tree
 
 #
-# status bar
+# Status bar
 #
 
-# UTF-8
 set -g status-utf8 on
 
-# start counting at 1
+# Start counting at 1
 set -g base-index 1
 set -g pane-base-index 1
 
-# window list
+# Window list
 set -g status-bg black
 set -g status-fg white
 set -g status-attr dim
 
-# active window in list
+# Active window
 set-window-option -g window-status-current-bg red
 set-window-option -g window-status-current-fg white
 set-window-option -g window-status-current-attr bright
 
-# left side
+# Left side
 set -g status-left '#[fg=green]#h'
 
-# right side
+# Right side
 set -g status-right '#[fg=yellow]%d %b %R'
 
 #
-# scroll buffer
+# Scroll buffer
 #
 
-# enable vi-style cursor keys
+# Enable vi-style cursor keys
 setw -g mode-keys vi
 
-# use <PREFIX Esc> to switch to copy mode
+# Use <PREFIX> <Esc> to switch to copy mode
 unbind [
 bind Escape copy-mode
 
-# use <PREFIX p> to paste
+# Use <PREFIX> <p> to paste
 bind p paste-buffer
 
-# use 'v' and 'y' like in vi
+# Use 'v' and 'y' like in vi
 bind -t vi-copy 'v' begin-selection
 bind -t vi-copy 'y' copy-selection
+
+#
+# Misc
+#
+
+# Terminal colors
+set -g default-terminal "screen-256color"
+
+# Log output to a text file on demand
+bind P pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
 
 # Use reattach-to-user-namespace
 set-option -g default-command "which reattach-to-user-namespace >/dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
 
+# Include individual configuration file
 if-shell "test -f ~/.tmux.conf.local" "source-file ~/.tmux.conf.local"

--- a/tmux.conf
+++ b/tmux.conf
@@ -99,6 +99,13 @@ bind -t vi-copy 'v' begin-selection
 bind -t vi-copy 'y' copy-selection
 
 #
+# Application launchers
+#
+
+# Split window horizontally for htop
+bind-key h split-window -h "htop"
+
+#
 # Misc
 #
 

--- a/vimrc
+++ b/vimrc
@@ -123,12 +123,12 @@ set numberwidth=5
 " Enable syntax highlighting
 syntax enable 
 
-set background=dark
-let g:solarized_termtrans = 1
-let g:solarized_termcolors=256
-
+" Solarized Dark color scheme using the vim-colors-solarized plugin
 try
     colorscheme solarized
+    set background=dark
+    let g:solarized_termtrans=1
+    let g:solarized_termcolors=256
 catch
 endtry
 
@@ -200,12 +200,6 @@ map <c-space> ?
 
 " Disable highlight when <leader><cr> is pressed
 map <silent> <leader><cr> :noh<cr>
-
-" Smart way to move between windows
-map <C-j> <C-W>j
-map <C-k> <C-W>k
-map <C-h> <C-W>h
-map <C-l> <C-W>l
 
 " Close the current buffer
 map <leader>bd :Bclose<cr>
@@ -285,6 +279,7 @@ func! DeleteTrailingWS()
 endfunc
 autocmd BufWrite *.py :call DeleteTrailingWS()
 autocmd BufWrite *.coffee :call DeleteTrailingWS()
+autocmd BufWrite *.rb :call DeleteTrailingWS()
 
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -337,23 +332,16 @@ let g:syntastic_eruby_ruby_quiet_messages =
 let g:vim_markdown_folding_disabled=1
 au BufRead,BufNewFile *.md setlocal textwidth=80
 
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Misc
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-" Remove the Windows ^M - when the encodings gets messed up
-noremap <Leader>m mmHmt:%s/<C-V><cr>//ge<cr>'tzt'm
-
-" Quickly open a buffer for scribble
-map <leader>q :e ~/buffer<cr>
-
-" Quickly open a markdown buffer for scribble
-map <leader>x :e ~/buffer.md<cr>
-
 " Toggle paste mode on and off
 map <leader>pp :setlocal paste!<cr>
 
 " Always start in line 1 of Git commit messages
-autocmd FileType gitcommit call setpos('.', [0, 1, 1, 0])
+au FileType gitcommit au! BufEnter COMMIT_EDITMSG call setpos('.', [0, 1, 1, 0])
+
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Helper functions

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -5,18 +5,12 @@ end
 call plug#begin('~/.vim/bundle')
 
 " Define bundles via Github repos
-Plug 'christoomey/vim-run-interactive'
 Plug 'ctrlpvim/ctrlp.vim'
 Plug 'pbrisbin/vim-mkdir'
-"Plug 'scrooloose/syntastic'
-"Plug 'slim-template/vim-slim'
-"Plug 'thoughtbot/vim-rspec'
-"Plug 'tpope/vim-bundler'
 Plug 'tpope/vim-endwise'
 Plug 'tpope/vim-eunuch'
 Plug 'tpope/vim-fugitive'
 Plug 'tpope/vim-rails'
-"Plug 'tpope/vim-repeat'
 Plug 'tpope/vim-surround'
 Plug 'vim-ruby/vim-ruby'
 Plug 'vim-scripts/tComment'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -17,6 +17,7 @@ Plug 'vim-scripts/tComment'
 Plug 'altercation/vim-colors-solarized'
 Plug 'rizzatti/dash.vim'
 Plug 'plasticboy/vim-markdown'
+Plug 'christoomey/vim-tmux-navigator'
 
 if filereadable(expand("~/.vimrc.bundles.local"))
   source ~/.vimrc.bundles.local


### PR DESCRIPTION
- Switch to Ctrl-s as tmux prefix. It's still easy to type with one hand and doesn't block important shell keystrokes like Ctrl-a.
- Simple switching between panes with Ctrl-HJKL. Thanks to vim-tmux-navigator, this works even between vim and tmux panes.
- First example for a tmux application pane: PREFIX h launches a htop pane.
- vim now automatically removes trailing whitespace in Ruby files which should relax Rubocop a bit.
- Removed a few unnecessary leader key bindings.
- Replaced the GIT_COMMIT line 1 hack with a better working alternative.
- Disabled balloon tooltips in Ruby files in GUI vim
- Fixed name of local GUI vim config to be `gvimrc.local`

@freistil/ops A big change, but an exciting one!
