### PR TITLE
Configuration for test-kitchen

### DIFF
--- a/kitchen/config.yml
+++ b/kitchen/config.yml
@@ -1,0 +1,12 @@
+---
+driver_plugin: docker
+driver_config:
+  provision_command:
+    - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 12.0.3
+    - env GEM_HOME=/tmp/verifier/gems GEM_PATH=/tmp/verifier/gems GEM_CACHE=/tmp/verifier/gems/cache /opt/chef/embedded/bin/gem install --no-ri --no-rdoc --bindir /tmp/verifier/bin thor busser busser-serverspec serverspec bundler && chown -R kitchen:kitchen /tmp/verifier
+  require_chef_omnibus: false
+  use_sudo: false
+
+provisioner:
+  name: chef_zero
+  chef_omnibus_root: /opt/chef

--- a/kitchen/config.yml
+++ b/kitchen/config.yml
@@ -2,7 +2,7 @@
 driver_plugin: docker
 driver_config:
   provision_command:
-    - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 12.0.3
+    - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 12.6.0
     - env GEM_HOME=/tmp/verifier/gems GEM_PATH=/tmp/verifier/gems GEM_CACHE=/tmp/verifier/gems/cache /opt/chef/embedded/bin/gem install --no-ri --no-rdoc --bindir /tmp/verifier/bin thor busser busser-serverspec serverspec bundler && chown -R kitchen:kitchen /tmp/verifier
   require_chef_omnibus: false
   use_sudo: false


### PR DESCRIPTION
This configuration file defines defaults for test-kitchen projects:
- Use Docker driver
- Pre-install Chef 12 and Busser packages for faster spin-up

@freistil/ops This configuration is highly recommended!
