### PR TITLE
use kitchen-sync as default transport into test-kitchen

### DIFF
--- a/kitchen/config.yml
+++ b/kitchen/config.yml
@@ -10,3 +10,6 @@ driver_config:
 provisioner:
   name: chef_zero
   chef_omnibus_root: /opt/chef
+
+transport:
+  name: sftp


### PR DESCRIPTION
Requires `chef gem install kitchen-sync` in our laptop script
