### PR TITLE
Use SFTP transport for test-kitchen

### DIFF
--- a/kitchen/config.yml
+++ b/kitchen/config.yml
@@ -7,6 +7,9 @@ driver_config:
   require_chef_omnibus: false
   use_sudo: false
 
+transport:
+  name: sftp
+
 provisioner:
   name: chef_zero
   chef_omnibus_root: /opt/chef


### PR DESCRIPTION
This change enables the faster SFTP transport for test-kitchen by
default.

@freistil/ops This is a huge speedup.
