### PR TITLE
test-kitchen: Add net-tools

### DIFF
--- a/kitchen/config.yml
+++ b/kitchen/config.yml
@@ -4,6 +4,7 @@ driver_config:
   provision_command:
     - curl -L https://www.opscode.com/chef/install.sh | bash -s -- -v 12.6.0
     - env GEM_HOME=/tmp/verifier/gems GEM_PATH=/tmp/verifier/gems GEM_CACHE=/tmp/verifier/gems/cache /opt/chef/embedded/bin/gem install --no-ri --no-rdoc --bindir /tmp/verifier/bin thor busser busser-serverspec serverspec bundler && chown -R kitchen:kitchen /tmp/verifier
+    - apt-get install -y net-tools
   require_chef_omnibus: false
   use_sudo: false
 


### PR DESCRIPTION
ServerSpec uses netstat to check for open ports. In order for this to
work, the `net-tools` package needs to be installed.
