### PR TITLE
Fix autojump configuration

### DIFF
--- a/zsh/configs/autojump
+++ b/zsh/configs/autojump
@@ -1,6 +1,10 @@
 # Enable autojump
 
-if which autojump >/dev/null; then
-  [[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]] && . $(brew --prefix)/etc/profile.d/autojump.sh
+PREFIX=""
+if [[ $(uname) == "Darwin"  ]]; then
+  PREFIX=$(brew --prefix)
 fi
 
+if which autojump >/dev/null; then
+  [[ -s $PREFIX/etc/profile.d/autojump.sh ]] && . $PREFIX/etc/profile.d/autojump.sh
+fi


### PR DESCRIPTION
Use `brew` on macOS only
