### PR TITLE
Remove default vi mode for zsh

### DIFF
--- a/zsh/keys.zsh
+++ b/zsh/keys.zsh
@@ -1,8 +1,3 @@
-# vi mode
-bindkey -v
-bindkey "^F" vi-cmd-mode
-bindkey jj vi-cmd-mode
-
 # handy keybindings
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line
@@ -11,4 +6,3 @@ bindkey "^R" history-incremental-search-backward
 bindkey "^P" history-search-backward
 bindkey "^Y" accept-and-hold
 bindkey "^N" insert-last-word
-bindkey -s "^T" "^[Isudo ^[A" # "t" for "toughguy"


### PR DESCRIPTION
This is a personal preference and should be enabled in a `.zshrc.local`
or personal `.zsh/vi-mode.zsh` (as I do it now).

@freistil/ops Another step towards server dotfiles
