### PR TITLE
make option for reattach-to-user-namespace work in fish

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -114,7 +114,7 @@ set -g default-terminal "screen-256color"
 bind P pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
 
 # Use reattach-to-user-namespace
-set-option -g default-command "which reattach-to-user-namespace >/dev/null && reattach-to-user-namespace -l $SHELL || $SHELL"
+set-option -g default-command 'exec reattach-to-user-namespace -l $SHELL'
 
 # Include individual configuration file
 if-shell "test -f ~/.tmux.conf.local" "source-file ~/.tmux.conf.local"


### PR DESCRIPTION
The old syntax was necessary for old tmux versions.
https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/blob/master/Usage.md#cross-platform-conditional-usage