### PR TITLE
Fix tmux configuration on Linux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -114,7 +114,7 @@ set -g default-terminal "screen-256color"
 bind P pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
 
 # Use reattach-to-user-namespace
-set-option -g default-command 'exec reattach-to-user-namespace -l $SHELL'
+if-shell 'test "$(uname)" = "Darwin"' "set-option -g default-command 'exec reattach-to-user-namespace -l $SHELL'"
 
 # Include individual configuration file
 if-shell "test -f ~/.tmux.conf.local" "source-file ~/.tmux.conf.local"


### PR DESCRIPTION
The reattach-to-user-namespace setting only works on macOS.