### PR TITLE
zsh: Explicitly enable Emacs mode

### DIFF
--- a/zsh/keys.zsh
+++ b/zsh/keys.zsh
@@ -1,3 +1,6 @@
+# Emacs mode
+bindkey -e
+
 # handy keybindings
 bindkey "^A" beginning-of-line
 bindkey "^E" end-of-line


### PR DESCRIPTION
Even I don't think vi mode makes sense for the CLI

@freistil/ops Do you?