### PR TITLE
Enable matchit.vim for block matching

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -338,6 +338,8 @@ au FileType gitcommit au! BufEnter COMMIT_EDITMSG call setpos('.', [0, 1, 1, 0])
 " Limit commit messages to 72 character lines
 au BufRead,BufNewFile COMMIT_EDITMSG setlocal textwidth=72
 
+" Enable matchit.vim for block matching (required by rubyblocks plugin)
+runtime macros/matchit.vim
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " => Helper functions


### PR DESCRIPTION
This makes vim behave correctly with Ruby blocks.