### PR TITLE
Fix zsh integration of rbenv

### DIFF
--- a/zsh/rbenv.zsh
+++ b/zsh/rbenv.zsh
@@ -1,5 +1,5 @@
 # load rbenv if available
+RBENV_PATH="$HOME/.rbenv/bin"
+test -d RBENV_PATH && export PATH="${RBENV_PATH}:${PATH}"
 RBENV=$(which rbenv)
-test -x "$RBENV" || RBENV="$HOME/.rbenv/bin/rbenv"
-
 test -x "$RBENV" && eval "$($RBENV init -)"


### PR DESCRIPTION
**Why is this change necessary?**

If installed via git repository, the `rbenv` binary could not be found in the shell `PATH`.

**How does it address the issue?**

If there is `~/.rbenv/bin`, it now gets added to `PATH`.