### PR TITLE
vim: Limit search scope for CtrlP

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -285,6 +285,9 @@ if executable('ag')
 
   " ag is fast enough that CtrlP doesn't need to cache
   let g:ctrlp_use_caching = 0
+
+  " search scope
+  let g:ctrlp_working_path_mode = 'a'
 endif
 
 " bind \ (backward slash) to grep shortcut


### PR DESCRIPTION
**Why is this change necessary?**

Using the CtrlP plugin for vim doesn't work well with the chef-cookbooks repository because it searches the whole repository by default.

**How does it address the issue?**

This change limits the search scope of CtrlP so that it won't search the whole chef-cookbooks repository if vim was started from `src/mycookbook`.

**What side effects does this change have?**

The search scope is limited to the directory subtree from which vim was started.